### PR TITLE
Haproxy backends options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To make this Role more reusable, it contains 3 different tags :
  - haproxy_configure : task which create the /etc/haproxy/haproxy.cfg
  - haproxy_service : tasks used to start/reload the service when there is a modification
 
+Change made in Jan. 11, 2018
+- support `options` in `haproxy_backends`
+- support `http-check` in `haproxy_backends`
+
 Example Playbook
 -------------------------
 

--- a/docs/exemple-loadbalancer.yml
+++ b/docs/exemple-loadbalancer.yml
@@ -37,6 +37,13 @@
      haproxy_backends:
      - name: webserver-ext
        balance: roundrobin
+       # httpchk option can be used with http-check to do
+       # health check (with http requests) to the backend server
+       # in this case, the returned result can not be 5xx error or
+       # this backend will be temporarily droped from sending requests to.
+       options:
+        - httpchk OPTIONS * HTTP/1.1\r\nHost:\ example.com
+       http_check: 'expect ! rstatus ^5'
        servers:
         - name: backend1
           ip: 192.168.0.100

--- a/docs/exemple-loadbalancer.yml
+++ b/docs/exemple-loadbalancer.yml
@@ -41,6 +41,10 @@
        # health check (with http requests) to the backend server
        # in this case, the returned result can not be 5xx error or
        # this backend will be temporarily droped from sending requests to.
+       # Please refer to:
+       # https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4.2-option%20httpchk
+       # https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#http-check%20expect
+       # https://www.haproxy.com/documentation/aloha/7-0/traffic-management/lb-layer7/health-checks/
        options:
         - httpchk OPTIONS * HTTP/1.1\r\nHost:\ example.com
        http_check: 'expect ! rstatus ^5'

--- a/docs/main.yml
+++ b/docs/main.yml
@@ -70,6 +70,9 @@
 #      mode: {value}                     (values: tcp|http|health)
 #      balance: {value}                  (values: roundrobin,leastconn,source,uri,url_param,hdr,...)
 #      cookie: {value}
+#      options:
+#          - {option}                    (values: httpchk,...)
+#      http_check: {value}               (values: expect ! rstatus ^5)
 #      servers:
 #          - name: {value}
 #            ip: {value}

--- a/templates/section_backend.cfg
+++ b/templates/section_backend.cfg
@@ -11,7 +11,6 @@ backend {{ backend.name }}
 {% if backend.cookie is defined %}
     cookie {{ backend.cookie }}
 {% endif %}
-
 {% if backend.options is defined %}
 {% for option in backend.options %}
     option {{ option }}

--- a/templates/section_backend.cfg
+++ b/templates/section_backend.cfg
@@ -16,8 +16,8 @@ backend {{ backend.name }}
     option {{ option }}
 {% endfor %}
 {% endif %}
-{% if backend.http-check is defined %}
-    http-check {{ backend.http-check }}
+{% if backend.http_check is defined %}
+    http-check {{ backend.http_check }}
 {% endif %}
 
 {%- if backend.servers is defined -%}

--- a/templates/section_backend.cfg
+++ b/templates/section_backend.cfg
@@ -16,6 +16,7 @@ backend {{ backend.name }}
 {% for option in backend.options %}
     option {{ option }}
 {% endfor %}
+{% endif %}
 
 {%- if backend.servers is defined -%}
 {% for server in backend.servers %}

--- a/templates/section_backend.cfg
+++ b/templates/section_backend.cfg
@@ -18,7 +18,7 @@ backend {{ backend.name }}
 {% endif %}
 {% if backend.http-check is defined %}
     http-check {{ backend.http-check }}
-{% enfif %}
+{% endif %}
 
 {%- if backend.servers is defined -%}
 {% for server in backend.servers %}

--- a/templates/section_backend.cfg
+++ b/templates/section_backend.cfg
@@ -12,6 +12,11 @@ backend {{ backend.name }}
     cookie {{ backend.cookie }}
 {% endif %}
 
+{% if backend.options is defined %}
+{% for option in backend.options %}
+    option {{ option }}
+{% endif %}
+
 {%- if backend.servers is defined -%}
 {% for server in backend.servers %}
     server {{ server.name }} {{ server.ip }}{% if server.port is defined %}:{{server.port }}{% else %}:80{% endif %} {% if server.params is defined %}{% for param in server.params %}{{ param }} {% endfor %}{% endif %}

--- a/templates/section_backend.cfg
+++ b/templates/section_backend.cfg
@@ -15,7 +15,7 @@ backend {{ backend.name }}
 {% if backend.options is defined %}
 {% for option in backend.options %}
     option {{ option }}
-{% endif %}
+{% endfor %}
 
 {%- if backend.servers is defined -%}
 {% for server in backend.servers %}

--- a/templates/section_backend.cfg
+++ b/templates/section_backend.cfg
@@ -16,6 +16,9 @@ backend {{ backend.name }}
     option {{ option }}
 {% endfor %}
 {% endif %}
+{% if backend.http-check is defined %}
+    http-check {{ backend.http-check }}
+{% enfif %}
 
 {%- if backend.servers is defined -%}
 {% for server in backend.servers %}


### PR DESCRIPTION
We need to support `option` and `http-check` in backend server definition block in haproxy.